### PR TITLE
Add emergency liquidations on risky loans

### DIFF
--- a/contracts/deploy/service/DeployInfra.sol
+++ b/contracts/deploy/service/DeployInfra.sol
@@ -36,7 +36,7 @@ contract DeployInfra is ProxyUtils {
         // init infra instances
         AccessControl(d.accessControl).initialize(users.access_control_admin);
         Lender(d.lender).initialize(
-            d.accessControl, d.delegation, d.oracle, 1.33e27, 1 hours, 1 days, 1e26
+            d.accessControl, d.delegation, d.oracle, 1.33e27, 1 hours, 1 days, 1e26, 0.91e27
         );
         Oracle(d.oracle).initialize(d.accessControl);
         Delegation(d.delegation).initialize(d.accessControl, d.oracle, 1 days);

--- a/contracts/lendingPool/Lender.sol
+++ b/contracts/lendingPool/Lender.sol
@@ -34,6 +34,7 @@ contract Lender is UUPSUpgradeable, AccessUpgradeable {
     /// @param _grace Grace period before an agent becomes liquidatable
     /// @param _expiry Expiry period after which an agent cannot be liquidated until called again
     /// @param _bonusCap Bonus cap for liquidations
+    /// @param _emergencyLiquidationThreshold Liquidation threshold below which grace periods are voided
     function initialize(
         address _accessControl,
         address _delegation,
@@ -41,7 +42,8 @@ contract Lender is UUPSUpgradeable, AccessUpgradeable {
         uint256 _targetHealth,
         uint256 _grace,
         uint256 _expiry,
-        uint256 _bonusCap
+        uint256 _bonusCap,
+        uint256 _emergencyLiquidationThreshold
     ) external initializer {
         __Access_init(_accessControl);
         __UUPSUpgradeable_init();
@@ -56,6 +58,7 @@ contract Lender is UUPSUpgradeable, AccessUpgradeable {
         $.grace = _grace;
         $.expiry = _expiry;
         $.bonusCap = _bonusCap;
+        $.emergencyLiquidationThreshold = _emergencyLiquidationThreshold;
     }
 
     /// @notice Borrow an asset

--- a/contracts/lendingPool/libraries/ValidationLogic.sol
+++ b/contracts/lendingPool/libraries/ValidationLogic.sol
@@ -90,13 +90,22 @@ library ValidationLogic {
     /// @notice Validate the liquidation of an agent
     /// @dev Health of above 1e27 is healthy, below is liquidatable
     /// @param health Health of an agent's position
+    /// @param emergencyHealth Emergency health below which the grace period is voided
     /// @param start Last liquidation start time
     /// @param grace Grace period duration
     /// @param expiry Liquidation duration after which it expires
-    function validateLiquidation(uint256 health, uint256 start, uint256 grace, uint256 expiry) external view {
+    function validateLiquidation(
+        uint256 health,
+        uint256 emergencyHealth,
+        uint256 start,
+        uint256 grace,
+        uint256 expiry
+    ) external view {
         if (health >= 1e27) revert HealthFactorNotBelowThreshold();
-        if (block.timestamp <= start + grace) revert GracePeriodNotOver();
-        if (block.timestamp >= start + expiry) revert LiquidationExpired();
+        if (emergencyHealth >= 1e27) {
+            if (block.timestamp <= start + grace) revert GracePeriodNotOver();
+            if (block.timestamp >= start + expiry) revert LiquidationExpired();
+        }
     }
 
     /// TODO Check that the asset is borrowable from the vault

--- a/contracts/lendingPool/libraries/types/DataTypes.sol
+++ b/contracts/lendingPool/libraries/types/DataTypes.sol
@@ -16,6 +16,7 @@ library DataTypes {
         uint256 grace;
         uint256 expiry;
         uint256 bonusCap;
+        uint256 emergencyLiquidationThreshold;
     }
 
     struct ReserveData {

--- a/test/lendingPool/Lender.invariants.t.sol
+++ b/test/lendingPool/Lender.invariants.t.sol
@@ -33,6 +33,7 @@ contract LenderInvariantsTest is TestDeployer {
     uint256 private constant BONUS_CAP = 1.1e27; // 110% bonus cap
     uint256 private constant GRACE_PERIOD = 1 days;
     uint256 private constant EXPIRY_PERIOD = 7 days;
+    uint256 private constant EMERGENCY_LIQUIDATION_THRESHOLD = 0.91e27; // CR <110% have no grace periods
 
     function setUp() public {
         _deployCapTestEnvironment();


### PR DESCRIPTION
Add a global variable whereby grace periods are voided if the emergency health of an agent falls below 1, meaning liquidations can happen if the agent is also below their liquidation threshold without waiting for the grace period.