### PR TITLE
Zellic C1

### DIFF
--- a/snapshots/Lender.gas.t.json
+++ b/snapshots/Lender.gas.t.json
@@ -1,4 +1,4 @@
 {
-  "simple_borrow": "632896",
-  "simple_repay": "313001"
+  "simple_borrow": "573201",
+  "simple_repay": "282447"
 }

--- a/snapshots/Vault.gas.t.json
+++ b/snapshots/Vault.gas.t.json
@@ -1,4 +1,4 @@
 {
-  "simple_burn": "262227",
-  "simple_mint": "245902"
+  "simple_burn": "224666",
+  "simple_mint": "209485"
 }


### PR DESCRIPTION
# Calculation error in ValidationLogic::validateBorrow resulting in a loss of funds

## Description
```
function validateBorrow(ILender.LenderStorage storage $, ILender.BorrowParams memory params) external {
// ...
    uint256 borrowCapacity = totalDelegation * ltv;

    if (newTotalDebt > borrowCapacity) revert CollateralCannotCoverNewBorrow();

    IDelegation($.delegation).setLastBorrow(params.agent);
}
```
Normally, this function will first calculate the maximum amount that the agent can borrow (i.e.,
borrowCapacity). When the total amount that the agent actually borrows (i.e., newTotalDebt)
exceeds its borrowCapacity, it will revert CollateralCannotCoverNewBorrow.
However, this function does not divide by 1e27 when calculating borrowCapacity. This causes the
total amount that the agent actually borrows to increase by 1e27 times the original amount.

## Resolution
Use `maxBorrowable()` to calculate the max an agent is allowed to borrow in the decimals of the asset.