### PR TITLE
ToB issues 1, 7, 9, 13, 25

### DIFF
--- a/contracts/feeAuction/FeeAuction.sol
+++ b/contracts/feeAuction/FeeAuction.sol
@@ -47,22 +47,37 @@ contract FeeAuction is IFeeAuction, UUPSUpgradeable, Access, FeeAuctionStorageUt
         $.minStartPrice = _minStartPrice;
     }
 
-    /// @notice Current price in the payment token, linearly decays toward 0 over time
+    /// @notice Current price in the payment token, linearly decays toward 10% of the start price over time
     /// @return price Current price
     function currentPrice() public view returns (uint256 price) {
         FeeAuctionStorage storage $ = get();
         uint256 elapsed = block.timestamp - $.startTimestamp;
         if (elapsed > $.duration) elapsed = $.duration;
-        price = $.startPrice * (1e27 - (elapsed * 1e27 / $.duration)) / 1e27;
+        price = $.startPrice * (1e27 - (elapsed * 0.9e27 / $.duration)) / 1e27;
     }
 
     /// @notice Buy fees in exchange for the payment token
     /// @dev Starts new auction where start price is double the settled price of this one
+    /// @param _maxPrice Maximum price to pay
     /// @param _assets Assets to buy
+    /// @param _minAmounts Minimum amounts to buy
     /// @param _receiver Receiver address for the assets
+    /// @param _deadline Deadline for the auction
     /// @param _callback Optional callback data
-    function buy(address[] calldata _assets, address _receiver, bytes calldata _callback) external {
+    function buy(
+        uint256 _maxPrice,
+        address[] calldata _assets,
+        uint256[] calldata _minAmounts,
+        address _receiver,
+        uint256 _deadline,
+        bytes calldata _callback
+    ) external {
         uint256 price = currentPrice();
+        if (price > _maxPrice) revert InvalidPrice();
+        if (_assets.length == 0 || _assets.length != _minAmounts.length) revert InvalidAssets();
+        if (_receiver == address(0)) revert InvalidReceiver();
+        if (_deadline < block.timestamp) revert InvalidDeadline();
+
         FeeAuctionStorage storage $ = get();
         $.startTimestamp = block.timestamp;
 
@@ -70,7 +85,7 @@ contract FeeAuction is IFeeAuction, UUPSUpgradeable, Access, FeeAuctionStorageUt
         if (newStartPrice < $.minStartPrice) newStartPrice = $.minStartPrice;
         $.startPrice = newStartPrice;
 
-        uint256[] memory balances = _transferOutAssets(_assets, _receiver);
+        uint256[] memory balances = _transferOutAssets(_assets, _minAmounts, _receiver);
 
         if (_callback.length > 0) IAuctionCallback(msg.sender).auctionCallback(_assets, balances, price, _callback);
 
@@ -84,6 +99,7 @@ contract FeeAuction is IFeeAuction, UUPSUpgradeable, Access, FeeAuctionStorageUt
     /// @param _startPrice New start price
     function setStartPrice(uint256 _startPrice) external checkAccess(this.setStartPrice.selector) {
         FeeAuctionStorage storage $ = get();
+        if (_startPrice < $.minStartPrice) revert InvalidStartPrice();
         $.startPrice = _startPrice;
         emit SetStartPrice(_startPrice);
     }
@@ -108,9 +124,10 @@ contract FeeAuction is IFeeAuction, UUPSUpgradeable, Access, FeeAuctionStorageUt
 
     /// @dev Transfer all specified assets to the receiver from this address
     /// @param _assets Asset addresses
+    /// @param _minAmounts Minimum amounts to buy
     /// @param _receiver Receiver address
     /// @return balances Balances transferred to receiver
-    function _transferOutAssets(address[] calldata _assets, address _receiver)
+    function _transferOutAssets(address[] calldata _assets, uint256[] calldata _minAmounts, address _receiver)
         internal
         returns (uint256[] memory balances)
     {
@@ -118,8 +135,10 @@ contract FeeAuction is IFeeAuction, UUPSUpgradeable, Access, FeeAuctionStorageUt
         balances = new uint256[](assetsLength);
         for (uint256 i; i < assetsLength; ++i) {
             address asset = _assets[i];
-            balances[i] = IERC20(asset).balanceOf(address(this));
-            if (balances[i] > 0) IERC20(asset).safeTransfer(_receiver, balances[i]);
+            uint256 balance = IERC20(asset).balanceOf(address(this));
+            balances[i] = balance;
+            if (balance < _minAmounts[i]) revert InsufficientBalance(asset, balance, _minAmounts[i]);
+            if (balance > 0) IERC20(asset).safeTransfer(_receiver, balance);
         }
     }
 

--- a/contracts/interfaces/IFeeAuction.sol
+++ b/contracts/interfaces/IFeeAuction.sol
@@ -28,10 +28,20 @@ interface IFeeAuction {
 
     /// @notice Buy fees in exchange for the payment token
     /// @dev Starts new auction where start price is double the settled price of this one
+    /// @param _maxPrice Maximum price to pay
     /// @param _assets Assets to buy
+    /// @param _minAmounts Minimum amounts to buy
     /// @param _receiver Receiver address for the assets
+    /// @param _deadline Deadline for the auction
     /// @param _callback Optional callback data
-    function buy(address[] calldata _assets, address _receiver, bytes calldata _callback) external;
+    function buy(
+        uint256 _maxPrice,
+        address[] calldata _assets,
+        uint256[] calldata _minAmounts,
+        address _receiver,
+        uint256 _deadline,
+        bytes calldata _callback
+    ) external;
 
     /// @notice Set the start price of the current auction
     /// @param _startPrice New start price
@@ -59,4 +69,22 @@ interface IFeeAuction {
 
     /// @dev Duration must be set
     error NoDuration();
+
+    /// @dev Start price must be greater than minimum start price
+    error InvalidStartPrice();
+
+    /// @dev Price must be less than maximum price
+    error InvalidPrice();
+
+    /// @dev Assets must be non-zero length and have matching lengths
+    error InvalidAssets();
+
+    /// @dev Receiver must be non-zero address
+    error InvalidReceiver();
+
+    /// @dev Deadline must be in the future
+    error InvalidDeadline();
+
+    /// @dev Insufficient balance for asset
+    error InsufficientBalance(address asset, uint256 balance, uint256 minAmount);
 }

--- a/snapshots/Lender.gas.t.json
+++ b/snapshots/Lender.gas.t.json
@@ -1,4 +1,4 @@
 {
-  "simple_borrow": "571948",
-  "simple_repay": "282447"
+  "simple_borrow": "585627",
+  "simple_repay": "282425"
 }

--- a/snapshots/Vault.gas.t.json
+++ b/snapshots/Vault.gas.t.json
@@ -1,4 +1,4 @@
 {
-  "simple_burn": "224666",
-  "simple_mint": "209485"
+  "simple_burn": "237482",
+  "simple_mint": "222301"
 }

--- a/test/lendingPool/FeeAuction.buy.t.sol
+++ b/test/lendingPool/FeeAuction.buy.t.sol
@@ -31,7 +31,11 @@ contract FeeAuctionBuyTest is TestDeployer {
         {
             vm.startPrank(realizer);
             lender.realizeInterest(address(usdc), 1);
-            cUSDFeeAuction.buy(usdVault.assets, realizer, "");
+            uint256 price = cUSDFeeAuction.currentPrice();
+            cUSD.approve(address(cUSDFeeAuction), type(uint256).max);
+            cUSDFeeAuction.buy(
+                price, usdVault.assets, new uint256[](usdVault.assets.length), realizer, block.timestamp, ""
+            );
             usdc.transfer(makeAddr("burn"), usdc.balanceOf(address(realizer)));
             vm.stopPrank();
         }
@@ -53,7 +57,9 @@ contract FeeAuctionBuyTest is TestDeployer {
 
         _timeTravel(1 hours);
 
-        assertEq(cUSDFeeAuction.currentPrice(), cUSDFeeAuction.minStartPrice() * 2 / 3); // fee auction is 3h long
+        assertEq(
+            cUSDFeeAuction.currentPrice(), cUSDFeeAuction.minStartPrice() * (1e27 - (1 hours * 0.9e27 / 3 hours)) / 1e27
+        ); // fee auction is 3h long
 
         // Save balances before buying
         uint256 usdcInterest = usdc.balanceOf(address(cUSDFeeAuction));
@@ -72,7 +78,10 @@ contract FeeAuctionBuyTest is TestDeployer {
 
             // Approve payment token (cUSD) for fee auction
             cUSD.approve(address(cUSDFeeAuction), type(uint256).max);
-            cUSDFeeAuction.buy(usdVault.assets, realizer, "");
+            uint256 price = cUSDFeeAuction.currentPrice();
+            cUSDFeeAuction.buy(
+                price, usdVault.assets, new uint256[](usdVault.assets.length), realizer, block.timestamp, ""
+            );
 
             // ensure realizer balance increased by the expected amount
             assertGt(usdc.balanceOf(address(realizer)), 11e6, "Realizer USDC balance should have increased");

--- a/test/scenario/Scenario.basic.t.sol
+++ b/test/scenario/Scenario.basic.t.sol
@@ -179,7 +179,7 @@ contract ScenarioBasicTest is TestDeployer {
             cUSD.approve(address(cUSDFeeAuction), 1000e18);
             uint256 startPrice = cUSDFeeAuction.currentPrice();
             console.log("Start price of fee auction", startPrice);
-            cUSDFeeAuction.buy(assets, mev_bot, "");
+            cUSDFeeAuction.buy(startPrice, assets, new uint256[](assets.length), mev_bot, block.timestamp, "");
 
             vm.stopPrank();
         }
@@ -230,8 +230,9 @@ contract ScenarioBasicTest is TestDeployer {
 
             uint256 startPrice = cUSDFeeAuction.startPrice();
             assertEq(startPrice, usdt_balance_before * 1e12);
+            uint256 price = cUSDFeeAuction.currentPrice();
             // console.log("Start price of fee auction", startPrice);
-            cUSDFeeAuction.buy(assets, mev_bot, "");
+            cUSDFeeAuction.buy(price, assets, new uint256[](assets.length), mev_bot, block.timestamp, "");
             uint256 usdt_balance_after = usdt.balanceOf(address(cUSDFeeAuction));
             uint256 cUSD_balance_after = cUSD.balanceOf(address(scUSD));
             console.log("USDT balance of fee auction after buy", usdt_balance_after);


### PR DESCRIPTION
Various fixes to Fee Auction. Also included is the addition of a deadline variable to ensure a dropped buy tx cannot be reused at a later time.

### 1. Missing input validation in FeeAuction.buy() allows payment without asset transfer.

Allow caller to input a minimum amount array to ensure they get at least what is asked for

### 7. Initial auction start price can be lower than minimum start price

Validate the setting of the start price to be above the minimum.

### 9. FeeAuction's buy function allows purchasing at sub-optimal prices by adding tokens during an active auction

Acknowledged but no changes.

### 13. Fee auction allows buying zero assets, leading to front-running attacks

Allow caller to input a maximum price they're willing to pay. If they are front-run then they will not pay more than expected.

### 25. Fee auction allows assets to be purchased for free

Increase the minimum price of any auction to at least 10% of the starting price.