### PR TITLE
ToB issue 3

### DIFF
--- a/contracts/delegation/providers/symbiotic/NetworkMiddleware.sol
+++ b/contracts/delegation/providers/symbiotic/NetworkMiddleware.sol
@@ -65,6 +65,7 @@ contract NetworkMiddleware is INetworkMiddleware, UUPSUpgradeable, Access, Netwo
         for (uint256 i; i < _agents.length; ++i) {
             $.vaults[_agents[i]].push(_vault);
         }
+        $.vaultRegistered[_vault] = true;
         emit VaultRegistered(_vault);
     }
 
@@ -252,6 +253,8 @@ contract NetworkMiddleware is INetworkMiddleware, UUPSUpgradeable, Access, Netwo
     /// @param _vault Vault address
     function _verifyVault(address _vault) internal view {
         NetworkMiddlewareStorage storage $ = getNetworkMiddlewareStorage();
+
+        if ($.vaultRegistered[_vault]) revert VaultAlreadyRegistered();
 
         if (!IRegistry($.vaultRegistry).isEntity(_vault)) {
             revert NotVault();

--- a/contracts/interfaces/INetworkMiddleware.sol
+++ b/contracts/interfaces/INetworkMiddleware.sol
@@ -14,6 +14,7 @@ interface INetworkMiddleware {
         uint256 feeAllowed;
         mapping(address => address) stakerRewarders; // vault => stakerRewarder
         mapping(address => address[]) vaults; // agent => vault[]
+        mapping(address => bool) vaultRegistered; // vault => isRegistered
     }
 
     enum SlasherType {
@@ -53,6 +54,9 @@ interface INetworkMiddleware {
 
     /// @dev No staker rewarder
     error NoStakerRewarder();
+
+    /// @dev Vault already registered
+    error VaultAlreadyRegistered();
 
     /// @dev Vault not initialized
     error VaultNotInitialized();

--- a/snapshots/Lender.gas.t.json
+++ b/snapshots/Lender.gas.t.json
@@ -1,4 +1,4 @@
 {
-  "simple_borrow": "571948",
-  "simple_repay": "282447"
+  "simple_borrow": "585627",
+  "simple_repay": "282425"
 }

--- a/snapshots/Vault.gas.t.json
+++ b/snapshots/Vault.gas.t.json
@@ -1,4 +1,4 @@
 {
-  "simple_burn": "224666",
-  "simple_mint": "209485"
+  "simple_burn": "237482",
+  "simple_mint": "222301"
 }


### PR DESCRIPTION
### 3. Vaults can be added to the middleware multiple times, leading to delegations being double-counted

Only allow vaults to be registered once. We are moving to one permanent vault per agent, so we should not need to register again for different agents.