### PR TITLE
ToB issue 5

### DIFF
--- a/contracts/vault/Vault.sol
+++ b/contracts/vault/Vault.sol
@@ -204,8 +204,7 @@ contract Vault is IVault, ERC20PermitUpgradeable, Access, Minter, FractionalRese
     /// @param _asset Asset to borrow
     /// @return amount Amount available
     function availableBalance(address _asset) external view returns (uint256 amount) {
-        VaultStorage storage $ = getVaultStorage();
-        amount = $.totalSupplies[_asset] - $.totalBorrows[_asset];
+        amount = VaultLogic.availableBalance(getVaultStorage(), _asset);
     }
 
     /// @notice Utilization rate of an asset

--- a/snapshots/Lender.gas.t.json
+++ b/snapshots/Lender.gas.t.json
@@ -1,4 +1,4 @@
 {
-  "simple_borrow": "571948",
-  "simple_repay": "282447"
+  "simple_borrow": "586012",
+  "simple_repay": "282425"
 }

--- a/snapshots/Vault.gas.t.json
+++ b/snapshots/Vault.gas.t.json
@@ -1,4 +1,4 @@
 {
-  "simple_burn": "224666",
-  "simple_mint": "209485"
+  "simple_burn": "238079",
+  "simple_mint": "222279"
 }


### PR DESCRIPTION
### 5. Inconsistent balance tracking in vault creates DoS for asset borrowing

Modify the burn and redeem logic to account for the available balance from the stored values. Remove any calls to `balanceOf` so only stored values are used for accounting.