### PR TITLE
ToB issue 6

### DIFF
--- a/contracts/vault/libraries/VaultLogic.sol
+++ b/contracts/vault/libraries/VaultLogic.sol
@@ -31,6 +31,9 @@ library VaultLogic {
     /// @dev Only non-supported assets can be rescued
     error AssetNotRescuable(address asset);
 
+    /// @dev Asset has supplies
+    error AssetHasSupplies(address asset);
+
     /// @dev Invalid min amounts out as they dont match the number of assets
     error InvalidMinAmountsOut();
 
@@ -190,6 +193,7 @@ library VaultLogic {
     /// @param $ Vault storage pointer
     /// @param _asset Asset address
     function removeAsset(IVault.VaultStorage storage $, address _asset) external {
+        if ($.totalSupplies[_asset] > 0) revert AssetHasSupplies(_asset);
         address[] memory cachedAssets = $.assets;
         uint256 length = cachedAssets.length;
         bool removed;

--- a/snapshots/Lender.gas.t.json
+++ b/snapshots/Lender.gas.t.json
@@ -1,4 +1,4 @@
 {
-  "simple_borrow": "571948",
-  "simple_repay": "282447"
+  "simple_borrow": "585627",
+  "simple_repay": "282425"
 }

--- a/snapshots/Vault.gas.t.json
+++ b/snapshots/Vault.gas.t.json
@@ -1,4 +1,4 @@
 {
-  "simple_burn": "224666",
-  "simple_mint": "209485"
+  "simple_burn": "237482",
+  "simple_mint": "222301"
 }


### PR DESCRIPTION
### 6. Unsafe asset removal without borrow validation

Check for supplies to be 0. If supplies are 0 then borrows must also be 0.