### PR TITLE
ToB issue 16, 22

### DIFF
--- a/contracts/vault/libraries/FractionalReserveLogic.sol
+++ b/contracts/vault/libraries/FractionalReserveLogic.sol
@@ -13,6 +13,9 @@ import { SafeERC20 } from "@openzeppelin/contracts/token/ERC20/utils/SafeERC20.s
 library FractionalReserveLogic {
     using SafeERC20 for IERC20;
 
+    /// @dev Loss not allowed from fractional reserve
+    error LossFromFractionalReserve(address asset, address vault, uint256 loss);
+
     /// @notice Invest unborrowed capital in a fractional reserve vault
     /// @param $ Storage pointer
     /// @param _asset Asset address
@@ -41,6 +44,8 @@ library FractionalReserveLogic {
                 uint256 redeemedAssets = IERC4626($.vault[_asset]).redeem(vaultBalance, address(this), address(this));
                 if (redeemedAssets > loanedAssets) {
                     IERC20(_asset).safeTransfer($.feeAuction, redeemedAssets - loanedAssets);
+                } else if (redeemedAssets < loanedAssets) {
+                    revert LossFromFractionalReserve(_asset, $.vault[_asset], loanedAssets - redeemedAssets);
                 }
             }
         }
@@ -62,7 +67,13 @@ library FractionalReserveLogic {
                 if (divestAmount > $.loaned[_asset]) divestAmount = $.loaned[_asset];
                 if (divestAmount > 0) {
                     $.loaned[_asset] -= divestAmount;
+
                     IERC4626($.vault[_asset]).withdraw(divestAmount, address(this), address(this));
+
+                    if (IERC20(_asset).balanceOf(address(this)) < divestAmount + assetBalance) {
+                        uint256 loss = divestAmount + assetBalance - IERC20(_asset).balanceOf(address(this));
+                        revert LossFromFractionalReserve(_asset, $.vault[_asset], loss);
+                    }
                 }
             }
         }

--- a/snapshots/Lender.gas.t.json
+++ b/snapshots/Lender.gas.t.json
@@ -1,4 +1,4 @@
 {
-  "simple_borrow": "571948",
-  "simple_repay": "282447"
+  "simple_borrow": "585627",
+  "simple_repay": "282425"
 }

--- a/snapshots/Vault.gas.t.json
+++ b/snapshots/Vault.gas.t.json
@@ -1,4 +1,4 @@
 {
-  "simple_burn": "224666",
-  "simple_mint": "209485"
+  "simple_burn": "237482",
+  "simple_mint": "222301"
 }


### PR DESCRIPTION
### 16. Unaccounted external vault investment losses can create withdrawal shortfalls

We will use Yearn vaults as the underlying, which have a default 0 loss tolerance.

### 22. Lack of verification on ERC4626 vault withdrawal amounts

Revert if the ERC4626 does not return the full requested balance.