### PR TITLE
Incorrect AccessControl address causes access control bypass

### DIFF
--- a/contracts/access/Access.sol
+++ b/contracts/access/Access.sol
@@ -33,6 +33,8 @@ abstract contract Access is IAccess, Initializable, AccessStorageUtils {
     /// @dev Check caller has access to a function, revert overwise
     /// @param _selector Function selector
     function _checkAccess(bytes4 _selector) internal view {
-        IAccessControl(getAccessStorage().accessControl).checkAccess(_selector, address(this), msg.sender);
+        bool hasAccess =
+            IAccessControl(getAccessStorage().accessControl).checkAccess(_selector, address(this), msg.sender);
+        if (!hasAccess) revert AccessDenied();
     }
 }

--- a/contracts/access/AccessControl.sol
+++ b/contracts/access/AccessControl.sol
@@ -28,8 +28,10 @@ contract AccessControl is IAccessControl, UUPSUpgradeable, AccessControlEnumerab
     /// @param _selector Function selector
     /// @param _contract Contract being called
     /// @param _caller Address to check role for
-    function checkAccess(bytes4 _selector, address _contract, address _caller) external view {
+    /// @return hasAccess True if access is granted
+    function checkAccess(bytes4 _selector, address _contract, address _caller) external view returns (bool hasAccess) {
         _checkRole(role(_selector, _contract), _caller);
+        hasAccess = true;
     }
 
     /// @notice Grant access to a specific method on a contract

--- a/contracts/interfaces/IAccess.sol
+++ b/contracts/interfaces/IAccess.sol
@@ -9,4 +9,7 @@ interface IAccess {
     struct AccessStorage {
         address accessControl;
     }
+
+    /// @notice Access is denied for the caller
+    error AccessDenied();
 }

--- a/contracts/interfaces/IAccessControl.sol
+++ b/contracts/interfaces/IAccessControl.sol
@@ -16,7 +16,8 @@ interface IAccessControl {
     /// @param _selector Function selector
     /// @param _contract Contract being called
     /// @param _caller Address to check role for
-    function checkAccess(bytes4 _selector, address _contract, address _caller) external view;
+    /// @return hasAccess True if access is granted, false otherwise
+    function checkAccess(bytes4 _selector, address _contract, address _caller) external view returns (bool hasAccess);
 
     /// @notice Grant access to a specific method on a contract
     /// @param _selector Function selector

--- a/test/mocks/MockAccessControl.sol
+++ b/test/mocks/MockAccessControl.sol
@@ -8,8 +8,9 @@ contract MockAccessControl is IAccessControl {
         // Initialize the admin
     }
 
-    function checkAccess(bytes4 _selector, address _contract, address _caller) external view {
+    function checkAccess(bytes4 _selector, address _contract, address _caller) external view returns (bool hasAccess) {
         // Always ok
+        hasAccess = true;
     }
 
     function grantAccess(bytes4 _selector, address _contract, address _caller) external {


### PR DESCRIPTION
https://github.com/cap-security-cartel/security-review-cap-contracts/issues/15

Implemented a bool return from the view function on `AccessControl`. However the revert still happens on `AccessControl` before the bool is returned if the caller is not authorized. Only if the caller is authorized is a true bool is returned, keeping the original operational flow while protecting against an incorrect setting.