### PR TITLE
Insufficient divestment in burn function excludes fees

### DIFF
--- a/contracts/vault/Vault.sol
+++ b/contracts/vault/Vault.sol
@@ -99,7 +99,7 @@ abstract contract Vault is IVault, ERC20PermitUpgradeable, Access, Minter, Fract
     {
         uint256 fee;
         (amountOut, fee) = getBurnAmount(_asset, _amountIn);
-        divest(_asset, amountOut);
+        divest(_asset, amountOut + fee);
         VaultLogic.burn(
             getVaultStorage(),
             MintBurnParams({
@@ -127,8 +127,13 @@ abstract contract Vault is IVault, ERC20PermitUpgradeable, Access, Minter, Fract
         returns (uint256[] memory amountsOut)
     {
         uint256[] memory fees;
+        uint256[] memory totalDivestAmounts = new uint256[](amountsOut.length);
         (amountsOut, fees) = getRedeemAmount(_amountIn);
-        divestMany(assets(), amountsOut);
+        for (uint256 i; i < amountsOut.length; i++) {
+            totalDivestAmounts[i] = amountsOut[i] + fees[i];
+        }
+
+        divestMany(assets(), totalDivestAmounts);
         VaultLogic.redeem(
             getVaultStorage(),
             RedeemParams({


### PR DESCRIPTION
https://github.com/cap-security-cartel/security-review-cap-contracts/issues/34

Implemented as suggested, also included the fee in the redemption divesting.