### PR TITLE
Interest rate manipulation for new borrowers

### DIFF
--- a/contracts/lendingPool/libraries/BorrowLogic.sol
+++ b/contracts/lendingPool/libraries/BorrowLogic.sol
@@ -86,7 +86,6 @@ library BorrowLogic {
         /// Can only repay up to the amount owed
         repaid = Math.min(params.amount, IERC20(reserve.debtToken).balanceOf(params.agent));
 
-        IDebtToken(reserve.debtToken).burn(params.agent, repaid);
         IERC20(params.asset).safeTransferFrom(params.caller, address(this), repaid);
 
         if (IERC20(reserve.debtToken).balanceOf(params.agent) == 0) {
@@ -128,6 +127,8 @@ library BorrowLogic {
         if (interestRepaid > 0) {
             IERC20(params.asset).safeTransfer(reserve.interestReceiver, interestRepaid);
         }
+
+        IDebtToken(reserve.debtToken).burn(params.agent, repaid);
 
         emit Repay(params.asset, params.agent, repaid);
     }


### PR DESCRIPTION
https://github.com/cap-security-cartel/security-review-cap-contracts/issues/39

I agree that there exists a scenario where an agent could fully max the utilization of an asset, causing the new interest rate to be increased for all borrowers. Then the agent fully repays leaving the interest rate still high but no interest is charged to that agent. However the recommendation targets the borrow portion of the process which I believe is not the issue.

### Current flow
`borrow -> update index` `update index -> repay`

Assets are borrowed from the vault, increasing the utilization. Index is updated with the stored interest rate and the new rate is calculated based on current utilization. When repaying the index is updated based on the stored interest rate and the new rate is calculated before the utilization changes. This calculation before utilization change is the issue as now the rate does not reflect the current state of the utilization.

### Auditor recommended flow
`update index -> borrow`

Switch the order of updating the index and the borrow. The index is updated using the stored interest rate and the new rate is calculated based on the current utilization, which hasn't changed. The borrow then happens but the interest rate does not reflect the current utilization. 

### Proposed flow
`borrow -> update index` `repay -> update index`

Switch the order of updating the index and the repay. It makes sense that we should only update the index after a change in the utilization. The interest rate can be recalculated and stored for the next period to be used in the next index update.