### PR TITLE
Admin can drain invested assets via rescueERC20 function

### DIFF
--- a/contracts/interfaces/IFractionalReserve.sol
+++ b/contracts/interfaces/IFractionalReserve.sol
@@ -1,6 +1,8 @@
 // SPDX-License-Identifier: BUSL-1.1
 pragma solidity ^0.8.28;
 
+import { EnumerableSet } from "@openzeppelin/contracts/utils/structs/EnumerableSet.sol";
+
 /// @title Fractional Reserve Interface
 /// @author kexley, @capLabs
 /// @notice Interface for the Fractional Reserve contract
@@ -11,6 +13,7 @@ interface IFractionalReserve {
         mapping(address => uint256) loaned;
         mapping(address => uint256) reserve;
         mapping(address => address) vault;
+        EnumerableSet.AddressSet vaults;
     }
 
     /// @notice Invest unborrowed capital in a fractional reserve vault (up to the reserve)
@@ -45,6 +48,10 @@ interface IFractionalReserve {
     /// @param _asset Asset address
     /// @return vaultAddress Vault address
     function fractionalReserveVault(address _asset) external view returns (address vaultAddress);
+
+    /// @notice Fractional reserve vaults
+    /// @return vaultAddresses Fractional reserve vaults
+    function fractionalReserveVaults() external view returns (address[] memory vaultAddresses);
 
     /// @notice Reserve amount for an asset
     /// @param _asset Asset address

--- a/contracts/vault/FractionalReserve.sol
+++ b/contracts/vault/FractionalReserve.sol
@@ -7,11 +7,15 @@ import { IFractionalReserve } from "../interfaces/IFractionalReserve.sol";
 import { FractionalReserveStorageUtils } from "../storage/FractionalReserveStorageUtils.sol";
 import { FractionalReserveLogic } from "./libraries/FractionalReserveLogic.sol";
 
+import { EnumerableSet } from "@openzeppelin/contracts/utils/structs/EnumerableSet.sol";
+
 /// @title Fractional Reserve
 /// @author kexley, @capLabs
 /// @notice Idle capital is put to work in fractional reserve vaults and can be recalled when
 /// withdrawing, redeeming or borrowing.
 abstract contract FractionalReserve is IFractionalReserve, Access, FractionalReserveStorageUtils {
+    using EnumerableSet for EnumerableSet.AddressSet;
+
     /// @dev Initialize unchained
     /// @param _interestReceiver Interest receiver address
     function __FractionalReserve_init(address _interestReceiver) internal onlyInitializing {
@@ -86,6 +90,12 @@ abstract contract FractionalReserve is IFractionalReserve, Access, FractionalRes
     /// @return vaultAddress Vault address
     function fractionalReserveVault(address _asset) external view returns (address vaultAddress) {
         vaultAddress = getFractionalReserveStorage().vault[_asset];
+    }
+
+    /// @notice Fractional reserve vaults
+    /// @return vaultAddresses Fractional reserve vaults
+    function fractionalReserveVaults() external view returns (address[] memory vaultAddresses) {
+        vaultAddresses = getFractionalReserveStorage().vaults.values();
     }
 
     /// @notice Reserve amount for an asset

--- a/contracts/vault/Vault.sol
+++ b/contracts/vault/Vault.sol
@@ -188,7 +188,7 @@ abstract contract Vault is IVault, ERC20PermitUpgradeable, Access, Minter, Fract
     /// @param _asset Asset to rescue
     /// @param _receiver Receiver of the rescue
     function rescueERC20(address _asset, address _receiver) external checkAccess(this.rescueERC20.selector) {
-        VaultLogic.rescueERC20(getVaultStorage(), _asset, _receiver);
+        VaultLogic.rescueERC20(getVaultStorage(), getFractionalReserveStorage(), _asset, _receiver);
     }
 
     /// @notice Get the list of assets supported by the vault

--- a/contracts/vault/libraries/FractionalReserveLogic.sol
+++ b/contracts/vault/libraries/FractionalReserveLogic.sol
@@ -5,6 +5,7 @@ import { IFractionalReserve } from "../../interfaces/IFractionalReserve.sol";
 import { IERC4626 } from "@openzeppelin/contracts/interfaces/IERC4626.sol";
 import { IERC20 } from "@openzeppelin/contracts/token/ERC20/IERC20.sol";
 import { SafeERC20 } from "@openzeppelin/contracts/token/ERC20/utils/SafeERC20.sol";
+import { EnumerableSet } from "@openzeppelin/contracts/utils/structs/EnumerableSet.sol";
 
 /// @title Fractional Reserve Logic
 /// @author kexley, @capLabs
@@ -12,9 +13,13 @@ import { SafeERC20 } from "@openzeppelin/contracts/token/ERC20/utils/SafeERC20.s
 /// withdrawing, redeeming or borrowing.
 library FractionalReserveLogic {
     using SafeERC20 for IERC20;
+    using EnumerableSet for EnumerableSet.AddressSet;
 
     /// @dev Loss not allowed from fractional reserve
     error LossFromFractionalReserve(address asset, address vault, uint256 loss);
+
+    /// @dev Fractional reserve vault already set
+    error FractionalReserveVaultAlreadySet(address vault);
 
     /// @dev Fractional reserve invested event
     event FractionalReserveInvested(address indexed asset, uint256 amount);
@@ -109,6 +114,8 @@ library FractionalReserveLogic {
         address _asset,
         address _vault
     ) external {
+        if ($.vault[_asset] != address(0)) $.vaults.remove($.vault[_asset]);
+        if (!$.vaults.add(_vault)) revert FractionalReserveVaultAlreadySet(_vault);
         $.vault[_asset] = _vault;
 
         emit FractionalReserveVaultUpdated(_asset, _vault);

--- a/contracts/vault/libraries/VaultLogic.sol
+++ b/contracts/vault/libraries/VaultLogic.sol
@@ -1,6 +1,7 @@
 // SPDX-License-Identifier: BUSL-1.1
 pragma solidity ^0.8.28;
 
+import { IFractionalReserve } from "../../interfaces/IFractionalReserve.sol";
 import { IVault } from "../../interfaces/IVault.sol";
 import { IERC20 } from "@openzeppelin/contracts/token/ERC20/IERC20.sol";
 import { SafeERC20 } from "@openzeppelin/contracts/token/ERC20/utils/SafeERC20.sol";
@@ -241,10 +242,16 @@ library VaultLogic {
 
     /// @notice Rescue an unsupported asset
     /// @param $ Vault storage pointer
+    /// @param reserve Fractional reserve storage pointer
     /// @param _asset Asset to rescue
     /// @param _receiver Receiver of the rescue
-    function rescueERC20(IVault.VaultStorage storage $, address _asset, address _receiver) external {
-        if (_listed($, _asset)) revert AssetNotRescuable(_asset);
+    function rescueERC20(
+        IVault.VaultStorage storage $,
+        IFractionalReserve.FractionalReserveStorage storage reserve,
+        address _asset,
+        address _receiver
+    ) external {
+        if (_listed($, _asset) || reserve.vaults.contains(_asset)) revert AssetNotRescuable(_asset);
         IERC20(_asset).safeTransfer(_receiver, IERC20(_asset).balanceOf(address(this)));
         emit RescueERC20(_asset, _receiver);
     }


### PR DESCRIPTION
https://github.com/cap-security-cartel/security-review-cap-contracts/issues/28

Implemented as suggested, using an enumerable set to store fractional reserve vaults and check against that list when rescuing.