### PR TITLE
Incorrect time scaling in interest calculation

### DIFF
--- a/contracts/lendingPool/libraries/ViewLogic.sol
+++ b/contracts/lendingPool/libraries/ViewLogic.sol
@@ -16,6 +16,8 @@ import { IERC20 } from "@openzeppelin/contracts/token/ERC20/IERC20.sol";
 library ViewLogic {
     using AgentConfiguration for ILender.AgentConfigurationMap;
 
+    uint256 constant SECONDS_IN_YEAR = 31536000;
+
     /// @notice Calculate the agent data
     /// @param $ Lender storage
     /// @param _agent Agent address
@@ -166,6 +168,6 @@ library ViewLogic {
         uint256 rate = IOracle($.oracle).restakerRate(_agent);
         uint256 elapsedTime = block.timestamp - reserve.lastRealizationTime[_agent];
 
-        accruedInterest = totalInterest * rate * elapsedTime / 1e27;
+        accruedInterest = totalInterest * rate * elapsedTime / (1e27 * SECONDS_IN_YEAR);
     }
 }

--- a/test/deploy/TestDeployer.sol
+++ b/test/deploy/TestDeployer.sol
@@ -165,9 +165,9 @@ contract TestDeployer is
             _initAaveRateOracle(env.libs, env.infra, env.ethVault.assets[i], env.ethOracleMocks.aaveDataProviders[i]);
         }
         for (uint256 i = 0; i < env.testUsers.agents.length; i++) {
-            /// 1.585e18 is 5% per year
-            uint256 increment = (i + 1) * 0.01585e18; // Vary the restakers rate by 1% each
-            _initRestakerRateForAgent(env.infra, env.testUsers.agents[i], uint256(1.585e18 + increment)); // Restakers rate is per second in ray
+            /// 0.05e27 is 5% per year
+            uint256 increment = (i + 1) * 0.0001e27; // Vary the restakers rate by 1% each
+            _initRestakerRateForAgent(env.infra, env.testUsers.agents[i], uint256(0.05e27 + increment)); // Restakers rate is annualized in ray
         }
 
         /// LENDER


### PR DESCRIPTION
https://github.com/cap-security-cartel/security-review-cap-contracts/issues/20

Implemented as suggested, switched restaker rate to be per annum instead of per second to match with the other rates.