### PR TITLE
Unsafe casting of potentially negative Chainlink price data

### DIFF
--- a/contracts/oracle/libraries/ChainlinkAdapter.sol
+++ b/contracts/oracle/libraries/ChainlinkAdapter.sol
@@ -15,7 +15,7 @@ library ChainlinkAdapter {
         uint8 decimals = IChainlink(_source).decimals();
         int256 intLatestAnswer;
         (, intLatestAnswer,, lastUpdated,) = IChainlink(_source).latestRoundData();
-        latestAnswer = uint256(intLatestAnswer);
+        latestAnswer = intLatestAnswer < 0 ? 0 : uint256(intLatestAnswer);
         if (decimals < 8) latestAnswer *= 10 ** (8 - decimals);
         if (decimals > 8) latestAnswer /= 10 ** (decimals - 8);
     }


### PR DESCRIPTION
https://github.com/cap-security-cartel/security-review-cap-contracts/issues/25

Instead of reverting on a negative price, return 0 and allow the price oracle to look to the backup oracle for a different price.