### PR TITLE
Borrows can be griefed when token reserves are low

### DIFF
--- a/contracts/interfaces/ILender.sol
+++ b/contracts/interfaces/ILender.sol
@@ -76,6 +76,7 @@ interface ILender {
         address asset;
         uint256 amount;
         address receiver;
+        bool maxBorrow;
     }
 
     /// @dev Repay parameters

--- a/contracts/lendingPool/Lender.sol
+++ b/contracts/lendingPool/Lender.sol
@@ -64,7 +64,14 @@ contract Lender is ILender, UUPSUpgradeable, Access, LenderStorageUtils {
     /// @param _receiver Receiver of the borrowed asset
     function borrow(address _asset, uint256 _amount, address _receiver) external {
         BorrowLogic.borrow(
-            getLenderStorage(), BorrowParams({ agent: msg.sender, asset: _asset, amount: _amount, receiver: _receiver })
+            getLenderStorage(),
+            BorrowParams({
+                agent: msg.sender,
+                asset: _asset,
+                amount: _amount,
+                receiver: _receiver,
+                maxBorrow: _amount == type(uint256).max
+            })
         );
     }
 

--- a/contracts/lendingPool/libraries/BorrowLogic.sol
+++ b/contracts/lendingPool/libraries/BorrowLogic.sol
@@ -49,6 +49,10 @@ library BorrowLogic {
         /// Realize restaker interest before borrowing
         realizeRestakerInterest($, params.agent, params.asset);
 
+        if (params.maxBorrow) {
+            params.amount = ViewLogic.maxBorrowable($, params.agent, params.asset);
+        }
+
         ValidationLogic.validateBorrow($, params);
 
         IDelegation($.delegation).setLastBorrow(params.agent);

--- a/contracts/lendingPool/libraries/ValidationLogic.sol
+++ b/contracts/lendingPool/libraries/ValidationLogic.sol
@@ -61,9 +61,10 @@ library ValidationLogic {
         if (params.receiver == address(0) || params.asset == address(0)) revert ZeroAddressNotValid();
         if ($.reservesData[params.asset].paused) revert ReservePaused();
 
-        uint256 borrowCapacity = ViewLogic.maxBorrowable($, params.agent, params.asset);
-
-        if (params.amount > borrowCapacity) revert CollateralCannotCoverNewBorrow();
+        if (!params.maxBorrow) {
+            uint256 borrowCapacity = ViewLogic.maxBorrowable($, params.agent, params.asset);
+            if (params.amount > borrowCapacity) revert CollateralCannotCoverNewBorrow();
+        }
     }
 
     /// @notice Validate the initialization of the liquidation of an agent


### PR DESCRIPTION
https://github.com/cap-security-cartel/security-review-cap-contracts/issues/37

Implemented the fix but with some adjustments. `validateBorrow()` is a view function, so we must adjust the `params.amount` in the main borrow function in the logic rather than the validation. If we check for the `maxBorrow` bool we avoid having to call `maxBorrowable()` twice which is fairly gas expensive.

As long as the maximal allowed amount is not less than the minimum borrow then it should still go through.