### PR TITLE
Inconsistent reserve pausing implementation

### DIFF
--- a/contracts/lendingPool/libraries/BorrowLogic.sol
+++ b/contracts/lendingPool/libraries/BorrowLogic.sol
@@ -195,6 +195,7 @@ library BorrowLogic {
         if (reserves < realization) {
             realization = reserves;
         }
+        if (reserve.paused) realization = 0;
     }
 
     /// @notice Calculate the maximum interest that can be realized for a restaker
@@ -208,11 +209,15 @@ library BorrowLogic {
         view
         returns (uint256 realization, uint256 unrealizedInterest)
     {
+        ILender.ReserveData storage reserve = $.reservesData[_asset];
         uint256 accruedInterest = ViewLogic.accruedRestakerInterest($, _agent, _asset);
-        uint256 reserves = IVault($.reservesData[_asset].vault).availableBalance(_asset);
+        uint256 reserves = IVault(reserve.vault).availableBalance(_asset);
 
         realization = accruedInterest;
-        if (realization > reserves) {
+        if (reserve.paused) {
+            unrealizedInterest = realization;
+            realization = 0;
+        } else if (realization > reserves) {
             unrealizedInterest = realization - reserves;
             realization = reserves;
         }


### PR DESCRIPTION
https://github.com/cap-security-cartel/security-review-cap-contracts/issues/43

Instead of reverting, reduce the maximum amounts that can be realized to 0. Interest will still accrue on paused markets but no more interest can be realized until the market is unpaused.