### PR TITLE
Repayment and liquidation may leave debt below minimum borrow threshold

### DIFF
--- a/contracts/lendingPool/libraries/ViewLogic.sol
+++ b/contracts/lendingPool/libraries/ViewLogic.sol
@@ -132,9 +132,7 @@ library ViewLogic {
 
         // Cap at the agent's debt for this asset
         uint256 agentDebt = debt($, _agent, _asset);
-        if (agentDebt < maxLiquidatableAmount) {
-            return agentDebt;
-        }
+        if (agentDebt < maxLiquidatableAmount + reserve.minBorrow) maxLiquidatableAmount = agentDebt;
     }
 
     /// @notice Get the current debt balances for an agent for a specific asset


### PR DESCRIPTION
https://github.com/cap-security-cartel/security-review-cap-contracts/issues/19

Implemented rounding down the repay to the maintain the minimum borrow unless it's a full repay. Liquidations now can liquidate fully if the resulting debt would be below the minimum. The agent debt shouldn't ever reach below the minimum borrow as the only way to burn debt tokens is via `repay()`.