### PR TITLE
Unclear _minShares param usage

### DIFF
--- a/contracts/testnetCampaign/PreMainnetVault.sol
+++ b/contracts/testnetCampaign/PreMainnetVault.sol
@@ -120,12 +120,11 @@ contract PreMainnetVault is ERC20Permit, OAppMessenger {
         emit Deposit(msg.sender, _amount, shares);
     }
 
-    /// @dev Preview deposit
+    /// @notice Preview deposit of underlying asset to mint cUSD on mainnet
     /// @param _amount Amount of underlying asset to deposit
-    /// @return shares Amount of shares minted
-    function previewDeposit(uint256 _amount) external view returns (uint256 shares) {
-        (uint256 amountOut,) = IMinter(address(cap)).getMintAmount(address(asset), _amount);
-        shares = stakedCap.previewDeposit(amountOut);
+    /// @return amountOut Amount of cUSD minted on mainnet
+    function previewDeposit(uint256 _amount) external view returns (uint256 amountOut) {
+        (amountOut,) = IMinter(address(cap)).getMintAmount(address(asset), _amount);
     }
 
     /// @dev Deposit into staked cap


### PR DESCRIPTION
https://github.com/electisec/cap-premainet-update/issues/6

Clarify that `_minShares` is actually `_minAmount` of cUSD to mint on mainnet. Edit the `previewDeposit()` view function to return the amount of cUSD minted on mainnet rather than shares, which is what we're actually using as the minimum in the `deposit()` call.