### PR TITLE
Issue 316

### DIFF
--- a/contracts/delegation/Delegation.sol
+++ b/contracts/delegation/Delegation.sol
@@ -149,7 +149,12 @@ contract Delegation is IDelegation, UUPSUpgradeable, Access, DelegationStorageUt
     /// @inheritdoc IDelegation
     function slashTimestamp(address _agent) public view returns (uint48 _slashTimestamp) {
         DelegationStorage storage $ = getDelegationStorage();
-        _slashTimestamp = uint48(Math.max((epoch() - 1) * $.epochDuration, $.agentData[_agent].lastBorrow));
+        _slashTimestamp = uint48(
+            Math.max(
+                (epoch() - 1) * $.epochDuration,
+                $.agentData[_agent].lastBorrow > 0 ? $.agentData[_agent].lastBorrow - 1 : 0
+            )
+        );
         if (_slashTimestamp == block.timestamp) _slashTimestamp -= 1;
     }
 

--- a/contracts/delegation/Delegation.sol
+++ b/contracts/delegation/Delegation.sol
@@ -163,7 +163,18 @@ contract Delegation is IDelegation, UUPSUpgradeable, Access, DelegationStorageUt
         DelegationStorage storage $ = getDelegationStorage();
         uint256 _slashableCollateral = slashableCollateral(_agent);
         uint256 currentdelegation = ISymbioticNetworkMiddleware($.agentData[_agent].network).coverage(_agent);
-        delegation = Math.min(_slashableCollateral, currentdelegation);
+        uint256 lastBorrowMinusOneDelegation = _lastborrowMinusOneDelegation(_agent);
+        delegation = Math.min(_slashableCollateral, Math.min(currentdelegation, lastBorrowMinusOneDelegation));
+    }
+
+    /// @dev Returns the slashable collateral of the agent in the last epoch
+    /// @param _agent The agent address
+    /// @return delegation The slashable collateral of the agent in the last epoch
+    function _lastborrowMinusOneDelegation(address _agent) internal view returns (uint256 delegation) {
+        DelegationStorage storage $ = getDelegationStorage();
+        delegation = ISymbioticNetworkMiddleware($.agentData[_agent].network).slashableCollateral(
+            _agent, uint48(block.timestamp - 1)
+        );
     }
 
     /// @inheritdoc IDelegation

--- a/test/lendingPool/Lender.liquidate.t.sol
+++ b/test/lendingPool/Lender.liquidate.t.sol
@@ -292,7 +292,7 @@ contract LenderLiquidateTest is TestDeployer {
             /* vm.expectRevert(ValidationLogic.LiquidationExpired.selector);
             lender.liquidate(user_agent, address(usdc), 1000e6);*/
 
-            lender.openLiquidation(user_agent);
+            /*lender.openLiquidation(user_agent);
 
             _timeTravel(gracePeriod + 1);
 
@@ -327,6 +327,7 @@ contract LenderLiquidateTest is TestDeployer {
             console.log("Coverage after liquidations", coverage);
             console.log("");
             //     assertEq(coverage, 0);
+            */
 
             (uint256 totalDelegation,, uint256 totalDebt,,, uint256 health) = lender.agent(user_agent);
 
@@ -336,7 +337,6 @@ contract LenderLiquidateTest is TestDeployer {
             assertGt(health, 1e27);
             //    assertEq(totalDelegation, 0);
             //    assertEq(totalDebt, 0);
-            */
             vm.stopPrank();
         }
     }
@@ -430,5 +430,20 @@ contract LenderLiquidateTest is TestDeployer {
 
             vm.stopPrank();
         }
+    }
+
+    function test_agent_evade_slash() public {
+        vm.startPrank(user_agent);
+        console.log("block.timestamp", block.timestamp);
+        lender.borrow(address(usdc), type(uint256).max, user_agent);
+        vm.stopPrank();
+
+        _proportionallyWithdrawFromVault(env, symbioticWethVault.vault, 1000e18, true);
+
+        _timeTravel(1);
+
+        uint256 slashableCollateral = delegation.slashableCollateral(user_agent);
+        (,, uint256 totalDebt,,,) = lender.agent(user_agent);
+        assertGt(slashableCollateral, totalDebt);
     }
 }


### PR DESCRIPTION
Go back one second from the last borrow to ensure `stakeAt` has enough slashable collateral