### PR TITLE
Add Coverage Caps

### DIFF
--- a/contracts/delegation/Delegation.sol
+++ b/contracts/delegation/Delegation.sol
@@ -176,10 +176,35 @@ contract Delegation is IDelegation, UUPSUpgradeable, Access, DelegationStorageUt
     /// @inheritdoc IDelegation
     function coverage(address _agent) public view returns (uint256 delegation) {
         DelegationStorage storage $ = getDelegationStorage();
+
         uint256 _slashableCollateral = slashableCollateral(_agent);
         uint256 currentdelegation = ISymbioticNetworkMiddleware($.agentData[_agent].network).coverage(_agent);
-        uint256 cap = $.coverageCap[_agent];
         uint256 lastBorrowMinusOneDelegation = _lastborrowMinusOneDelegation(_agent);
+        uint256 cap = $.coverageCap[_agent];
+
+        uint256 lastBorrowTime = $.agentData[_agent].lastBorrow;
+
+        // If we have debt, check if the CURRENT epoch start has coverage
+        if (lastBorrowTime > 0) {
+            uint48 currentEpochStart = uint48(epoch() * $.epochDuration);
+
+            // Query coverage at the current epoch boundary
+            uint256 currentEpochCoverage =
+                ISymbioticNetworkMiddleware($.agentData[_agent].network).slashableCollateral(_agent, currentEpochStart);
+
+            // If current epoch coverage is less than lastBorrow coverage, use current epoch as ceiling
+            if (currentEpochCoverage < lastBorrowMinusOneDelegation) {
+                delegation = Math.min(
+                    cap,
+                    Math.min(
+                        currentEpochCoverage,
+                        Math.min(_slashableCollateral, Math.min(currentdelegation, lastBorrowMinusOneDelegation))
+                    )
+                );
+                return delegation;
+            }
+        }
+
         delegation =
             Math.min(Math.min(_slashableCollateral, cap), Math.min(currentdelegation, lastBorrowMinusOneDelegation));
     }
@@ -189,8 +214,9 @@ contract Delegation is IDelegation, UUPSUpgradeable, Access, DelegationStorageUt
     /// @return delegation The slashable collateral of the agent in the last epoch
     function _lastborrowMinusOneDelegation(address _agent) internal view returns (uint256 delegation) {
         DelegationStorage storage $ = getDelegationStorage();
-        delegation = ISymbioticNetworkMiddleware($.agentData[_agent].network)
-            .slashableCollateral(_agent, uint48(block.timestamp - 1));
+        delegation = ISymbioticNetworkMiddleware($.agentData[_agent].network).slashableCollateral(
+            _agent, uint48(block.timestamp - 1)
+        );
     }
 
     /// @inheritdoc IDelegation

--- a/contracts/delegation/Delegation.sol
+++ b/contracts/delegation/Delegation.sol
@@ -202,7 +202,7 @@ contract Delegation is IDelegation, UUPSUpgradeable, Access, DelegationStorageUt
     }
 
     /// @inheritdoc IDelegation
-    function collateral(address _agent) public view returns (address collateralAddress) {
+    function collateral(address _agent) external view returns (address collateralAddress) {
         DelegationStorage storage $ = getDelegationStorage();
         address network = $.agentData[_agent].network;
         if (network == address(0)) return address(0);

--- a/contracts/delegation/Delegation.sol
+++ b/contracts/delegation/Delegation.sol
@@ -139,6 +139,15 @@ contract Delegation is IDelegation, UUPSUpgradeable, Access, DelegationStorageUt
     }
 
     /// @inheritdoc IDelegation
+    function setCoverageCap(address _collateral, uint256 _coverageCap)
+        external
+        checkAccess(this.setCoverageCap.selector)
+    {
+        getDelegationStorage().coverageCap[_collateral] = _coverageCap;
+        emit SetCoverageCap(_collateral, _coverageCap);
+    }
+
+    /// @inheritdoc IDelegation
     function epochDuration() external view returns (uint256 duration) {
         DelegationStorage storage $ = getDelegationStorage();
         duration = $.epochDuration;
@@ -172,8 +181,10 @@ contract Delegation is IDelegation, UUPSUpgradeable, Access, DelegationStorageUt
         DelegationStorage storage $ = getDelegationStorage();
         uint256 _slashableCollateral = slashableCollateral(_agent);
         uint256 currentdelegation = ISymbioticNetworkMiddleware($.agentData[_agent].network).coverage(_agent);
+        uint256 cap = $.coverageCap[collateral(_agent)];
         uint256 lastBorrowMinusOneDelegation = _lastborrowMinusOneDelegation(_agent);
-        delegation = Math.min(_slashableCollateral, Math.min(currentdelegation, lastBorrowMinusOneDelegation));
+        delegation =
+            Math.min(Math.min(_slashableCollateral, cap), Math.min(currentdelegation, lastBorrowMinusOneDelegation));
     }
 
     /// @dev Returns the slashable collateral of the agent in the last epoch
@@ -181,9 +192,8 @@ contract Delegation is IDelegation, UUPSUpgradeable, Access, DelegationStorageUt
     /// @return delegation The slashable collateral of the agent in the last epoch
     function _lastborrowMinusOneDelegation(address _agent) internal view returns (uint256 delegation) {
         DelegationStorage storage $ = getDelegationStorage();
-        delegation = ISymbioticNetworkMiddleware($.agentData[_agent].network).slashableCollateral(
-            _agent, uint48(block.timestamp - 1)
-        );
+        delegation = ISymbioticNetworkMiddleware($.agentData[_agent].network)
+            .slashableCollateral(_agent, uint48(block.timestamp - 1));
     }
 
     /// @inheritdoc IDelegation
@@ -192,6 +202,14 @@ contract Delegation is IDelegation, UUPSUpgradeable, Access, DelegationStorageUt
         uint48 _slashTimestamp = slashTimestamp(_agent);
         _slashableCollateral =
             ISymbioticNetworkMiddleware($.agentData[_agent].network).slashableCollateral(_agent, _slashTimestamp);
+    }
+
+    /// @inheritdoc IDelegation
+    function collateral(address _agent) public view returns (address collateralAddress) {
+        DelegationStorage storage $ = getDelegationStorage();
+        address network = $.agentData[_agent].network;
+        if (network == address(0)) return address(0);
+        collateralAddress = ISymbioticNetworkMiddleware(network).collateral(_agent);
     }
 
     /// @inheritdoc IDelegation
@@ -222,6 +240,11 @@ contract Delegation is IDelegation, UUPSUpgradeable, Access, DelegationStorageUt
     /// @inheritdoc IDelegation
     function feeRecipient() external view returns (address) {
         return getDelegationStorage().feeRecipient;
+    }
+
+    /// @inheritdoc IDelegation
+    function coverageCap(address _collateral) external view returns (uint256 cap) {
+        cap = getDelegationStorage().coverageCap[_collateral];
     }
 
     /// @inheritdoc UUPSUpgradeable

--- a/contracts/delegation/Delegation.sol
+++ b/contracts/delegation/Delegation.sol
@@ -139,12 +139,9 @@ contract Delegation is IDelegation, UUPSUpgradeable, Access, DelegationStorageUt
     }
 
     /// @inheritdoc IDelegation
-    function setCoverageCap(address _collateral, uint256 _coverageCap)
-        external
-        checkAccess(this.setCoverageCap.selector)
-    {
-        getDelegationStorage().coverageCap[_collateral] = _coverageCap;
-        emit SetCoverageCap(_collateral, _coverageCap);
+    function setCoverageCap(address _agent, uint256 _coverageCap) external checkAccess(this.setCoverageCap.selector) {
+        getDelegationStorage().coverageCap[_agent] = _coverageCap;
+        emit SetCoverageCap(_agent, _coverageCap);
     }
 
     /// @inheritdoc IDelegation
@@ -181,7 +178,7 @@ contract Delegation is IDelegation, UUPSUpgradeable, Access, DelegationStorageUt
         DelegationStorage storage $ = getDelegationStorage();
         uint256 _slashableCollateral = slashableCollateral(_agent);
         uint256 currentdelegation = ISymbioticNetworkMiddleware($.agentData[_agent].network).coverage(_agent);
-        uint256 cap = $.coverageCap[collateral(_agent)];
+        uint256 cap = $.coverageCap[_agent];
         uint256 lastBorrowMinusOneDelegation = _lastborrowMinusOneDelegation(_agent);
         delegation =
             Math.min(Math.min(_slashableCollateral, cap), Math.min(currentdelegation, lastBorrowMinusOneDelegation));
@@ -243,8 +240,8 @@ contract Delegation is IDelegation, UUPSUpgradeable, Access, DelegationStorageUt
     }
 
     /// @inheritdoc IDelegation
-    function coverageCap(address _collateral) external view returns (uint256 cap) {
-        cap = getDelegationStorage().coverageCap[_collateral];
+    function coverageCap(address _agent) external view returns (uint256 cap) {
+        cap = getDelegationStorage().coverageCap[_agent];
     }
 
     /// @inheritdoc UUPSUpgradeable

--- a/contracts/delegation/Delegation.sol
+++ b/contracts/delegation/Delegation.sol
@@ -181,32 +181,16 @@ contract Delegation is IDelegation, UUPSUpgradeable, Access, DelegationStorageUt
         uint256 currentdelegation = ISymbioticNetworkMiddleware($.agentData[_agent].network).coverage(_agent);
         uint256 lastBorrowMinusOneDelegation = _lastborrowMinusOneDelegation(_agent);
         uint256 cap = $.coverageCap[_agent];
+        uint48 currentEpochStart = uint48(epoch() * $.epochDuration);
 
-        uint256 lastBorrowTime = $.agentData[_agent].lastBorrow;
+        // Query coverage at the current epoch boundary
+        uint256 currentEpochCoverage =
+            ISymbioticNetworkMiddleware($.agentData[_agent].network).slashableCollateral(_agent, currentEpochStart);
 
-        // If we have debt, check if the CURRENT epoch start has coverage
-        if (lastBorrowTime > 0) {
-            uint48 currentEpochStart = uint48(epoch() * $.epochDuration);
-
-            // Query coverage at the current epoch boundary
-            uint256 currentEpochCoverage =
-                ISymbioticNetworkMiddleware($.agentData[_agent].network).slashableCollateral(_agent, currentEpochStart);
-
-            // If current epoch coverage is less than lastBorrow coverage, use current epoch as ceiling
-            if (currentEpochCoverage < lastBorrowMinusOneDelegation) {
-                delegation = Math.min(
-                    cap,
-                    Math.min(
-                        currentEpochCoverage,
-                        Math.min(_slashableCollateral, Math.min(currentdelegation, lastBorrowMinusOneDelegation))
-                    )
-                );
-                return delegation;
-            }
-        }
-
-        delegation =
-            Math.min(Math.min(_slashableCollateral, cap), Math.min(currentdelegation, lastBorrowMinusOneDelegation));
+        delegation = Math.min(
+            Math.min(currentEpochCoverage, _slashableCollateral),
+            Math.min(cap, Math.min(currentdelegation, lastBorrowMinusOneDelegation))
+        );
     }
 
     /// @dev Returns the slashable collateral of the agent in the last epoch

--- a/contracts/delegation/providers/eigenlayer/EigenServiceManager.sol
+++ b/contracts/delegation/providers/eigenlayer/EigenServiceManager.sol
@@ -278,6 +278,14 @@ contract EigenServiceManager is IEigenServiceManager, UUPSUpgradeable, Access, E
     }
 
     /// @inheritdoc IEigenServiceManager
+    function collateral(address _operator) external view returns (address collateralAddress) {
+        EigenServiceManagerStorage storage $ = getEigenServiceManagerStorage();
+        CachedOperatorData storage operatorData = $.operators[_operator];
+        if (operatorData.strategy == address(0)) return address(0);
+        collateralAddress = address(IStrategy(operatorData.strategy).underlyingToken());
+    }
+
+    /// @inheritdoc IEigenServiceManager
     function operatorSetId(address _operator) external view returns (uint32) {
         EigenServiceManagerStorage storage $ = getEigenServiceManagerStorage();
         CachedOperatorData storage operatorData = $.operators[_operator];
@@ -377,9 +385,8 @@ contract EigenServiceManager is IEigenServiceManager, UUPSUpgradeable, Access, E
             IAllocationManager.OperatorSet({ avs: address(this), id: operatorData.operatorSetId });
 
         // @dev clear the burn or redistributable shares, this sends them to the service manager
-        IStrategyManager($.eigen.strategyManager).clearBurnOrRedistributableSharesByStrategy(
-            operatorSet, slashId, _strategy
-        );
+        IStrategyManager($.eigen.strategyManager)
+            .clearBurnOrRedistributableSharesByStrategy(operatorSet, slashId, _strategy);
     }
 
     /// @notice Create a rewards submission
@@ -435,9 +442,8 @@ contract EigenServiceManager is IEigenServiceManager, UUPSUpgradeable, Access, E
             description: "interest"
         });
 
-        IRewardsCoordinator($.eigen.rewardsCoordinator).createOperatorDirectedOperatorSetRewardsSubmission(
-            operatorSet, rewardsSubmissions
-        );
+        IRewardsCoordinator($.eigen.rewardsCoordinator)
+            .createOperatorDirectedOperatorSetRewardsSubmission(operatorSet, rewardsSubmissions);
     }
 
     /// @notice Check if the token has enough allowance for the spender
@@ -459,8 +465,8 @@ contract EigenServiceManager is IEigenServiceManager, UUPSUpgradeable, Access, E
         uint8 decimals = IERC20Metadata(collateralAddress).decimals();
         (uint256 collateralPrice,) = IOracle($.oracle).getPrice(collateralAddress);
 
-        uint256 collateral = _getSlashableStake(_operator);
-        uint256 collateralValue = collateral * collateralPrice / (10 ** decimals);
+        uint256 collateralAmount = _getSlashableStake(_operator);
+        uint256 collateralValue = collateralAmount * collateralPrice / (10 ** decimals);
 
         return collateralValue;
     }
@@ -470,19 +476,19 @@ contract EigenServiceManager is IEigenServiceManager, UUPSUpgradeable, Access, E
     /// @param _strategy The strategy address
     /// @param _oracle The oracle address
     /// @return collateralValue The collateral value
-    /// @return collateral The collateral
+    /// @return collateralAmount The collateral amount
     function _coverageByStrategy(address _operator, address _strategy, address _oracle)
         private
         view
-        returns (uint256 collateralValue, uint256 collateral)
+        returns (uint256 collateralValue, uint256 collateralAmount)
     {
         address collateralAddress = address(IStrategy(_strategy).underlyingToken());
         uint8 decimals = IERC20Metadata(collateralAddress).decimals();
         (uint256 collateralPrice,) = IOracle(_oracle).getPrice(collateralAddress);
 
         // @dev get the minimum slashable stake
-        collateral = _minimumSlashableStake(_operator, _strategy);
-        collateralValue = collateral * collateralPrice / (10 ** decimals);
+        collateralAmount = _minimumSlashableStake(_operator, _strategy);
+        collateralValue = collateralAmount * collateralPrice / (10 ** decimals);
     }
 
     /// @notice Get the slashable stake for a given operator and strategy
@@ -510,9 +516,10 @@ contract EigenServiceManager is IEigenServiceManager, UUPSUpgradeable, Access, E
     function _slashableStakeInQueue(address _operator, address _strategy) private view returns (uint256) {
         EigenServiceManagerStorage storage $ = getEigenServiceManagerStorage();
         // @dev get the slashable stake in queue which are waiting to be withdrawn
-        return IStrategy(_strategy).sharesToUnderlyingView(
-            IDelegationManager($.eigen.delegationManager).getSlashableSharesInQueue(_operator, _strategy)
-        );
+        return IStrategy(_strategy)
+            .sharesToUnderlyingView(
+                IDelegationManager($.eigen.delegationManager).getSlashableSharesInQueue(_operator, _strategy)
+            );
     }
 
     /// @notice Get the minimum slashable stake for a given operator and strategy
@@ -530,9 +537,8 @@ contract EigenServiceManager is IEigenServiceManager, UUPSUpgradeable, Access, E
         strategies[0] = _strategy;
 
         // @dev get the minimum slashable stake at the current block
-        uint256[][] memory slashableShares = IAllocationManager($.eigen.allocationManager).getMinimumSlashableStake(
-            operatorSet, operators, strategies, uint32(block.number)
-        );
+        uint256[][] memory slashableShares = IAllocationManager($.eigen.allocationManager)
+            .getMinimumSlashableStake(operatorSet, operators, strategies, uint32(block.number));
         return IStrategy(_strategy).sharesToUnderlyingView(slashableShares[0][0]);
     }
 

--- a/contracts/delegation/providers/symbiotic/SymbioticNetworkMiddleware.sol
+++ b/contracts/delegation/providers/symbiotic/SymbioticNetworkMiddleware.sol
@@ -105,9 +105,8 @@ contract SymbioticNetworkMiddleware is
 
         address operator = ISymbioticNetwork($.network).getOperator(_agent);
 
-        ISlasher(vault.slasher()).slash(
-            subnetwork(operator), operator, slashShareOfCollateral, _timestamp, new bytes(0)
-        );
+        ISlasher(vault.slasher())
+            .slash(subnetwork(operator), operator, slashShareOfCollateral, _timestamp, new bytes(0));
 
         IBurnerRouter(vault.burner()).triggerTransfer(address(this));
         IERC20(vault.collateral()).safeTransfer(_recipient, slashShareOfCollateral);
@@ -124,16 +123,17 @@ contract SymbioticNetworkMiddleware is
         address stakerRewarder = $.vaults[_vault].stakerRewarder;
 
         IERC20(_token).forceApprove(stakerRewarder, _amount);
-        IStakerRewards(stakerRewarder).distributeRewards(
-            $.network, _token, _amount, abi.encode(uint48(block.timestamp - 1), $.feeAllowed, "", "")
-        );
+        IStakerRewards(stakerRewarder)
+            .distributeRewards(
+                $.network, _token, _amount, abi.encode(uint48(block.timestamp - 1), $.feeAllowed, "", "")
+            );
     }
 
     /// @inheritdoc ISymbioticNetworkMiddleware
     function coverageByVault(address _network, address _agent, address _vault, address _oracle, uint48 _timestamp)
         public
         view
-        returns (uint256 collateralValue, uint256 collateral)
+        returns (uint256 collateralValue, uint256 collateralAmount)
     {
         (IBurnerRouter burnerRouter, uint8 decimals, uint256 collateralPrice) =
             _getVaultInfo(_network, _agent, _vault, _oracle);
@@ -142,8 +142,9 @@ contract SymbioticNetworkMiddleware is
 
         address operator = ISymbioticNetwork(_network).getOperator(_agent);
 
-        collateral = IBaseDelegator(IVault(_vault).delegator()).stakeAt(subnetwork(operator), operator, _timestamp, "");
-        collateralValue = collateral * collateralPrice / (10 ** decimals);
+        collateralAmount =
+            IBaseDelegator(IVault(_vault).delegator()).stakeAt(subnetwork(operator), operator, _timestamp, "");
+        collateralValue = collateralAmount * collateralPrice / (10 ** decimals);
     }
 
     /// @inheritdoc ISymbioticNetworkMiddleware
@@ -153,7 +154,7 @@ contract SymbioticNetworkMiddleware is
         address _vault,
         address _oracle,
         uint48 _timestamp
-    ) public view returns (uint256 collateralValue, uint256 collateral) {
+    ) public view returns (uint256 collateralValue, uint256 collateralAmount) {
         (IBurnerRouter burnerRouter, uint8 decimals, uint256 collateralPrice) =
             _getVaultInfo(_network, _agent, _vault, _oracle);
 
@@ -161,8 +162,8 @@ contract SymbioticNetworkMiddleware is
 
         ISlasher slasher = ISlasher(IVault(_vault).slasher());
         address operator = ISymbioticNetwork(_network).getOperator(_agent);
-        collateral = slasher.slashableStake(subnetwork(operator), operator, _timestamp, "");
-        collateralValue = collateral * collateralPrice / (10 ** decimals);
+        collateralAmount = slasher.slashableStake(subnetwork(operator), operator, _timestamp, "");
+        collateralValue = collateralAmount * collateralPrice / (10 ** decimals);
     }
 
     /// @inheritdoc ISymbioticNetworkMiddleware
@@ -178,11 +179,7 @@ contract SymbioticNetworkMiddleware is
     }
 
     /// @inheritdoc ISymbioticNetworkMiddleware
-    function slashableCollateral(address _agent, uint48 _timestamp)
-        public
-        view
-        returns (uint256 _slashableCollateral)
-    {
+    function slashableCollateral(address _agent, uint48 _timestamp) public view returns (uint256 _slashableCollateral) {
         SymbioticNetworkMiddlewareStorage storage $ = getSymbioticNetworkMiddlewareStorage();
         address _vault = $.agentsToVault[_agent];
         address _network = $.network;
@@ -205,6 +202,14 @@ contract SymbioticNetworkMiddleware is
     /// @inheritdoc ISymbioticNetworkMiddleware
     function vaults(address _agent) external view returns (address vaultAddress) {
         vaultAddress = getSymbioticNetworkMiddlewareStorage().agentsToVault[_agent];
+    }
+
+    /// @inheritdoc ISymbioticNetworkMiddleware
+    function collateral(address _agent) external view returns (address collateralAddress) {
+        SymbioticNetworkMiddlewareStorage storage $ = getSymbioticNetworkMiddlewareStorage();
+        address vault = $.agentsToVault[_agent];
+        if (vault == address(0)) return address(0);
+        collateralAddress = IVault(vault).collateral();
     }
 
     /// @dev Get vault info

--- a/contracts/deploy/service/ConfigureAccessControl.sol
+++ b/contracts/deploy/service/ConfigureAccessControl.sol
@@ -42,6 +42,7 @@ contract ConfigureAccessControl {
         accessControl.grantAccess(Delegation.slash.selector, infra.delegation, infra.lender);
         accessControl.grantAccess(Delegation.setLtvBuffer.selector, infra.delegation, users.delegation_admin);
         accessControl.grantAccess(Delegation.setFeeRecipient.selector, infra.delegation, users.delegation_admin);
+        accessControl.grantAccess(Delegation.setCoverageCap.selector, infra.delegation, users.delegation_admin);
         accessControl.grantAccess(bytes4(0), infra.delegation, users.access_control_admin);
     }
 }

--- a/contracts/interfaces/IDelegation.sol
+++ b/contracts/interfaces/IDelegation.sol
@@ -15,6 +15,8 @@ interface IDelegation is IRestakerRewardReceiver {
     /// @param oracle Oracle address
     /// @param epochDuration Epoch duration
     /// @param ltvBuffer LTV buffer from LT
+    /// @param feeRecipient Fee recipient
+    /// @param coverageCap Coverage cap for an agent
     struct DelegationStorage {
         EnumerableSet.AddressSet agents;
         mapping(address => AgentData) agentData;

--- a/contracts/interfaces/IDelegation.sol
+++ b/contracts/interfaces/IDelegation.sol
@@ -73,10 +73,10 @@ interface IDelegation is IRestakerRewardReceiver {
     /// @param feeRecipient Fee recipient
     event SetFeeRecipient(address feeRecipient);
 
-    /// @notice Set the coverage cap
-    /// @param collateral Collateral address
+    /// @notice Set the coverage cap for an agent
+    /// @param agent Agent address
     /// @param coverageCap Coverage cap in USD (8 decimals)
-    event SetCoverageCap(address collateral, uint256 coverageCap);
+    event SetCoverageCap(address agent, uint256 coverageCap);
 
     /// @notice Agent does not exist
     error AgentDoesNotExist();
@@ -155,10 +155,10 @@ interface IDelegation is IRestakerRewardReceiver {
     /// @param _feeRecipient Fee recipient
     function setFeeRecipient(address _feeRecipient) external;
 
-    /// @notice Set the coverage cap
-    /// @param _collateral Collateral address
+    /// @notice Set the coverage cap for an agent
+    /// @param _agent Agent address
     /// @param _coverageCap Coverage cap in USD (8 decimals)
-    function setCoverageCap(address _collateral, uint256 _coverageCap) external;
+    function setCoverageCap(address _agent, uint256 _coverageCap) external;
 
     /// @notice Get the epoch duration
     /// @return duration Epoch duration in seconds
@@ -222,8 +222,8 @@ interface IDelegation is IRestakerRewardReceiver {
     /// @return recipient Fee recipient
     function feeRecipient() external view returns (address recipient);
 
-    /// @notice Get the coverage cap for a collateral
-    /// @param _collateral Collateral address
+    /// @notice Get the coverage cap for an agent
+    /// @param _agent Agent address
     /// @return cap Coverage cap in USD (8 decimals)
-    function coverageCap(address _collateral) external view returns (uint256 cap);
+    function coverageCap(address _agent) external view returns (uint256 cap);
 }

--- a/contracts/interfaces/IDelegation.sol
+++ b/contracts/interfaces/IDelegation.sol
@@ -23,6 +23,7 @@ interface IDelegation is IRestakerRewardReceiver {
         uint256 epochDuration;
         uint256 ltvBuffer;
         address feeRecipient;
+        mapping(address => uint256) coverageCap;
     }
 
     /// @dev Agent data
@@ -71,6 +72,11 @@ interface IDelegation is IRestakerRewardReceiver {
     /// @notice Set the fee recipient
     /// @param feeRecipient Fee recipient
     event SetFeeRecipient(address feeRecipient);
+
+    /// @notice Set the coverage cap
+    /// @param collateral Collateral address
+    /// @param coverageCap Coverage cap in USD (8 decimals)
+    event SetCoverageCap(address collateral, uint256 coverageCap);
 
     /// @notice Agent does not exist
     error AgentDoesNotExist();
@@ -149,6 +155,11 @@ interface IDelegation is IRestakerRewardReceiver {
     /// @param _feeRecipient Fee recipient
     function setFeeRecipient(address _feeRecipient) external;
 
+    /// @notice Set the coverage cap
+    /// @param _collateral Collateral address
+    /// @param _coverageCap Coverage cap in USD (8 decimals)
+    function setCoverageCap(address _collateral, uint256 _coverageCap) external;
+
     /// @notice Get the epoch duration
     /// @return duration Epoch duration in seconds
     /// @dev The duration between epochs. Pretty much the amount of time we have to slash the delegated collateral, if delegation is changed on the symbiotic vault.
@@ -178,6 +189,11 @@ interface IDelegation is IRestakerRewardReceiver {
     /// @return _slashableCollateral Amount in USD (8 decimals) that a agent has provided as slashable collateral from the delegators
     function slashableCollateral(address _agent) external view returns (uint256 _slashableCollateral);
 
+    /// @notice Get the collateral address for an agent
+    /// @param _agent Agent address
+    /// @return collateralAddress Collateral address
+    function collateral(address _agent) external view returns (address collateralAddress);
+
     /// @notice Fetch active network address
     /// @param _agent Agent address
     /// @return networkAddress network address
@@ -205,4 +221,9 @@ interface IDelegation is IRestakerRewardReceiver {
     /// @notice Get the fee recipient
     /// @return recipient Fee recipient
     function feeRecipient() external view returns (address recipient);
+
+    /// @notice Get the coverage cap for a collateral
+    /// @param _collateral Collateral address
+    /// @return cap Coverage cap in USD (8 decimals)
+    function coverageCap(address _collateral) external view returns (uint256 cap);
 }

--- a/contracts/interfaces/IEigenServiceManager.sol
+++ b/contracts/interfaces/IEigenServiceManager.sol
@@ -180,6 +180,13 @@ interface IEigenServiceManager {
     function slashableCollateral(address operator, uint48 timestamp) external view returns (uint256);
 
     /**
+     * @notice Collateral of an agent
+     * @param _operator Operator address
+     * @return collateralAddress Collateral address
+     */
+    function collateral(address _operator) external view returns (address collateralAddress);
+
+    /**
      * @notice Sets the epochs between distributions
      * @param _epochsBetweenDistributions The epochs between distributions
      */

--- a/contracts/interfaces/ISymbioticNetworkMiddleware.sol
+++ b/contracts/interfaces/ISymbioticNetworkMiddleware.sol
@@ -132,11 +132,11 @@ interface ISymbioticNetworkMiddleware {
     /// @param _oracle Oracle address
     /// @param _timestamp Timestamp to check coverage at
     /// @return collateralValue Coverage value in USD (8 decimals)
-    /// @return collateral Coverage amount in the vault's collateral token decimals
+    /// @return collateralAmount Coverage amount in the vault's collateral token decimals
     function coverageByVault(address _network, address _agent, address _vault, address _oracle, uint48 _timestamp)
         external
         view
-        returns (uint256 collateralValue, uint256 collateral);
+        returns (uint256 collateralValue, uint256 collateralAmount);
 
     /// @notice Slashable collateral of an agent by a specific vault at a given timestamp
     /// @param _network Network address
@@ -145,13 +145,14 @@ interface ISymbioticNetworkMiddleware {
     /// @param _oracle Oracle address
     /// @param _timestamp Timestamp to check slashable collateral at
     /// @return collateralValue Slashable collateral value in USD (8 decimals)
+    /// @return collateralAmount Slashable collateral amount in the vault's collateral token decimals
     function slashableCollateralByVault(
         address _network,
         address _agent,
         address _vault,
         address _oracle,
         uint48 _timestamp
-    ) external view returns (uint256 collateralValue, uint256 collateral);
+    ) external view returns (uint256 collateralValue, uint256 collateralAmount);
 
     /// @notice Coverage of an agent by Symbiotic vaults
     /// @param _agent Agent address
@@ -162,10 +163,7 @@ interface ISymbioticNetworkMiddleware {
     /// @param _agent Agent address
     /// @param _timestamp Timestamp to check slashable collateral at
     /// @return _slashableCollateral Slashable collateral amount in USD (8 decimals)
-    function slashableCollateral(address _agent, uint48 _timestamp)
-        external
-        view
-        returns (uint256 _slashableCollateral);
+    function slashableCollateral(address _agent, uint48 _timestamp) external view returns (uint256 _slashableCollateral);
 
     /// @notice Subnetwork identifier
     /// @param _agent Agent address
@@ -181,4 +179,9 @@ interface ISymbioticNetworkMiddleware {
     /// @param _agent Agent address
     /// @return vault Vault address
     function vaults(address _agent) external view returns (address vault);
+
+    /// @notice Collateral of an agent
+    /// @param _agent Agent address
+    /// @return collateralAddress Collateral address
+    function collateral(address _agent) external view returns (address collateralAddress);
 }

--- a/test/delegation/Delegation.slash.t.sol
+++ b/test/delegation/Delegation.slash.t.sol
@@ -144,4 +144,28 @@ contract DelegationSlashTest is TestDeployer {
 
         vm.stopPrank();
     }
+
+    function test_slash_delegation_coverage_cap() public {
+        vm.startPrank(env.infra.lender);
+
+        uint256 coverageBefore = delegation.coverage(user_agent);
+        address collateral = delegation.collateral(user_agent);
+        uint256 coverageCap = delegation.coverageCap(collateral);
+
+        /// Set coverage cap to 100 USD of collateral
+        vm.startPrank(env.users.delegation_admin);
+        delegation.setCoverageCap(collateral, 100e8);
+        vm.stopPrank();
+
+        uint256 coverageAfter = delegation.coverage(user_agent);
+        assertEq(coverageAfter, 100e8);
+
+        /// Set coverage cap to a large number
+        vm.startPrank(env.users.delegation_admin);
+        delegation.setCoverageCap(collateral, 1_000_000_000_000e8);
+        vm.stopPrank();
+
+        coverageAfter = delegation.coverage(user_agent);
+        assertEq(coverageAfter, coverageBefore);
+    }
 }

--- a/test/delegation/Delegation.slash.t.sol
+++ b/test/delegation/Delegation.slash.t.sol
@@ -149,12 +149,10 @@ contract DelegationSlashTest is TestDeployer {
         vm.startPrank(env.infra.lender);
 
         uint256 coverageBefore = delegation.coverage(user_agent);
-        address collateral = delegation.collateral(user_agent);
-        uint256 coverageCap = delegation.coverageCap(collateral);
 
         /// Set coverage cap to 100 USD of collateral
         vm.startPrank(env.users.delegation_admin);
-        delegation.setCoverageCap(collateral, 100e8);
+        delegation.setCoverageCap(user_agent, 100e8);
         vm.stopPrank();
 
         uint256 coverageAfter = delegation.coverage(user_agent);
@@ -162,7 +160,7 @@ contract DelegationSlashTest is TestDeployer {
 
         /// Set coverage cap to a large number
         vm.startPrank(env.users.delegation_admin);
-        delegation.setCoverageCap(collateral, 1_000_000_000_000e8);
+        delegation.setCoverageCap(user_agent, 1_000_000_000_000e8);
         vm.stopPrank();
 
         coverageAfter = delegation.coverage(user_agent);

--- a/test/deploy/TestDeployer.sol
+++ b/test/deploy/TestDeployer.sol
@@ -9,13 +9,15 @@ import { EigenServiceManager } from "../../contracts/delegation/providers/eigenl
 
 import { SymbioticAgentManager } from "../../contracts/delegation/providers/symbiotic/SymbioticAgentManager.sol";
 import { SymbioticNetwork } from "../../contracts/delegation/providers/symbiotic/SymbioticNetwork.sol";
-import { SymbioticNetworkMiddleware } from
-    "../../contracts/delegation/providers/symbiotic/SymbioticNetworkMiddleware.sol";
+import {
+    SymbioticNetworkMiddleware
+} from "../../contracts/delegation/providers/symbiotic/SymbioticNetworkMiddleware.sol";
 
 import { FeeConfig, VaultConfig } from "../../contracts/deploy/interfaces/DeployConfigs.sol";
 import { ISymbioticAgentManager } from "../../contracts/interfaces/ISymbioticAgentManager.sol";
-import { IOperatorNetworkSpecificDelegator } from
-    "@symbioticfi/core/src/interfaces/delegator/IOperatorNetworkSpecificDelegator.sol";
+import {
+    IOperatorNetworkSpecificDelegator
+} from "@symbioticfi/core/src/interfaces/delegator/IOperatorNetworkSpecificDelegator.sol";
 
 import { MockChainlinkPriceFeed } from "../mocks/MockChainlinkPriceFeed.sol";
 import { MockNetworkMiddleware } from "../mocks/MockNetworkMiddleware.sol";
@@ -23,7 +25,9 @@ import { MockNetworkMiddleware } from "../mocks/MockNetworkMiddleware.sol";
 import { AccessControl } from "../../contracts/access/AccessControl.sol";
 
 import {
-    EigenConfig, EigenUsersConfig, EigenVaultConfig
+    EigenConfig,
+    EigenUsersConfig,
+    EigenVaultConfig
 } from "../../contracts/deploy/interfaces/EigenDeployConfig.sol";
 import { SymbioticVaultParams } from "../../contracts/deploy/interfaces/SymbioticsDeployConfigs.sol";
 import { SymbioticNetworkAdapterParams } from "../../contracts/deploy/interfaces/SymbioticsDeployConfigs.sol";
@@ -40,9 +44,12 @@ import { DeployImplems } from "../../contracts/deploy/service/DeployImplems.sol"
 import { DeployInfra } from "../../contracts/deploy/service/DeployInfra.sol";
 import { DeployLibs } from "../../contracts/deploy/service/DeployLibs.sol";
 import { DeployVault } from "../../contracts/deploy/service/DeployVault.sol";
-import { ConfigureSymbioticOptIns } from
-    "../../contracts/deploy/service/providers/symbiotic/ConfigureSymbioticOptIns.sol";
-import { DeployCapNetworkAdapter } from "../../contracts/deploy/service/providers/symbiotic/DeployCapNetworkAdapter.sol";
+import {
+    ConfigureSymbioticOptIns
+} from "../../contracts/deploy/service/providers/symbiotic/ConfigureSymbioticOptIns.sol";
+import {
+    DeployCapNetworkAdapter
+} from "../../contracts/deploy/service/providers/symbiotic/DeployCapNetworkAdapter.sol";
 import { ProxyUtils } from "../../contracts/deploy/utils/ProxyUtils.sol";
 import { SymbioticAddressbook, SymbioticUtils } from "../../contracts/deploy/utils/SymbioticUtils.sol";
 import { FeeAuction } from "../../contracts/feeAuction/FeeAuction.sol";
@@ -145,8 +152,9 @@ contract TestDeployer is
         env.permissionedOracleMocks = _deployOracleMocks(env.permissionedMocks);
 
         console.log("deploying usdVault");
-        env.usdVault =
-            _deployVault(env.implems, env.infra, "Cap USD", "cUSD", env.usdOracleMocks.assets, env.users.insurance_fund);
+        env.usdVault = _deployVault(
+            env.implems, env.infra, "Cap USD", "cUSD", env.usdOracleMocks.assets, env.users.insurance_fund
+        );
 
         if (useMockBackingNetwork()) {
             console.log("skipping lzperiphery");
@@ -243,6 +251,15 @@ contract TestDeployer is
             _restakers[1] = env.testUsers.restakers[2];
             _registerToEigenServiceManager(eigenAb, eigenAdmin, env.eigen.eigenConfig.agentManager, _agents, _restakers);
             _initEigenDelegations(eigenAb, env.eigen.eigenConfig.eigenServiceManager, _agents, _restakers, 10);
+
+            // Set coverage cap for Eigen collateral
+            vm.startPrank(env.users.delegation_admin);
+            for (uint256 i = 0; i < _agents.length; i++) {
+                address agent = _agents[i];
+                address eigenCollateral = Delegation(env.infra.delegation).collateral(agent);
+                Delegation(env.infra.delegation).setCoverageCap(eigenCollateral, 1_000_000_000_000e8);
+            }
+            vm.stopPrank();
         }
 
         /// Deploy Symbiotic Network Adapter
@@ -293,6 +310,13 @@ contract TestDeployer is
             _symbioticVaultConfigToEnv(_vault);
             _symbioticNetworkRewardsConfigToEnv(_rewards);
 
+            vm.startPrank(env.users.delegation_admin);
+            for (uint256 i = 0; i < env.testUsers.agents.length; i++) {
+                address symbioticAgent = env.testUsers.agents[i];
+                address symbioticCollateral = Delegation(env.infra.delegation).collateral(symbioticAgent);
+                Delegation(env.infra.delegation).setCoverageCap(symbioticCollateral, 1_000_000_000_000e8);
+            }
+
             vm.stopPrank();
         }
 
@@ -314,10 +338,9 @@ contract TestDeployer is
 
         console.log(env.symbiotic.users.vault_admin);
 
-        (address vault, address delegator, address burner, address slasher, address stakerRewarder) =
-        CapSymbioticVaultFactory(env.symbiotic.networkAdapter.vaultFactory).createVault(
-            env.symbiotic.users.vault_admin, collateral, agent, env.symbiotic.networkAdapter.network
-        );
+        (address vault, address delegator, address burner, address slasher, address stakerRewarder) = CapSymbioticVaultFactory(
+                env.symbiotic.networkAdapter.vaultFactory
+            ).createVault(env.symbiotic.users.vault_admin, collateral, agent, env.symbiotic.networkAdapter.network);
 
         _vault.vault = vault;
         _vault.collateral = collateral;

--- a/test/deploy/TestDeployer.sol
+++ b/test/deploy/TestDeployer.sol
@@ -251,15 +251,6 @@ contract TestDeployer is
             _restakers[1] = env.testUsers.restakers[2];
             _registerToEigenServiceManager(eigenAb, eigenAdmin, env.eigen.eigenConfig.agentManager, _agents, _restakers);
             _initEigenDelegations(eigenAb, env.eigen.eigenConfig.eigenServiceManager, _agents, _restakers, 10);
-
-            // Set coverage cap for Eigen collateral
-            vm.startPrank(env.users.delegation_admin);
-            for (uint256 i = 0; i < _agents.length; i++) {
-                address agent = _agents[i];
-                address eigenCollateral = Delegation(env.infra.delegation).collateral(agent);
-                Delegation(env.infra.delegation).setCoverageCap(eigenCollateral, 1_000_000_000_000e8);
-            }
-            vm.stopPrank();
         }
 
         /// Deploy Symbiotic Network Adapter
@@ -312,11 +303,8 @@ contract TestDeployer is
 
             vm.startPrank(env.users.delegation_admin);
             for (uint256 i = 0; i < env.testUsers.agents.length; i++) {
-                address symbioticAgent = env.testUsers.agents[i];
-                address symbioticCollateral = Delegation(env.infra.delegation).collateral(symbioticAgent);
-                Delegation(env.infra.delegation).setCoverageCap(symbioticCollateral, 1_000_000_000_000e8);
+                Delegation(env.infra.delegation).setCoverageCap(env.testUsers.agents[i], 1_000_000_000_000e8);
             }
-
             vm.stopPrank();
         }
 

--- a/test/mocks/MockNetworkMiddleware.sol
+++ b/test/mocks/MockNetworkMiddleware.sol
@@ -12,6 +12,7 @@ contract MockNetworkMiddleware is ISymbioticNetworkMiddleware {
     mapping(address => uint256) public mockSlashableCollateral;
     mapping(address => mapping(address => uint256)) public mockCollateralByVault;
     mapping(address => mapping(address => uint256)) public mockSlashableCollateralByVault;
+    mapping(address => mapping(address => address)) public mockCollateralAddressByVault;
 
     function initialize(
         address _accessControl,
@@ -37,15 +38,15 @@ contract MockNetworkMiddleware is ISymbioticNetworkMiddleware {
 
         address _vault = _storage.agentsToVault[_agent];
         mockCollateralByVault[_agent][_vault] -= mockCollateralByVault[_agent][_vault] * _slashShare / 1e18;
-        mockSlashableCollateralByVault[_agent][_vault] -=
-            mockSlashableCollateralByVault[_agent][_vault] * _slashShare / 1e18;
+        mockSlashableCollateralByVault[_agent][_vault] -= mockSlashableCollateralByVault[_agent][_vault] * _slashShare
+        / 1e18;
         emit Slash(_agent, _recipient, _slashShare);
     }
 
     function coverageByVault(address, address _agent, address _vault, address, uint48)
         external
         view
-        returns (uint256 collateralValue, uint256 collateral)
+        returns (uint256 collateralValue, uint256 collateralAmount)
     {
         return (mockCollateralByVault[_agent][_vault], mockCollateralByVault[_agent][_vault]);
     }
@@ -53,7 +54,7 @@ contract MockNetworkMiddleware is ISymbioticNetworkMiddleware {
     function slashableCollateralByVault(address, address _agent, address _vault, address, uint48)
         external
         view
-        returns (uint256 collateralValue, uint256 collateral)
+        returns (uint256 collateralValue, uint256 collateralAmount)
     {
         return (mockSlashableCollateralByVault[_agent][_vault], mockSlashableCollateralByVault[_agent][_vault]);
     }
@@ -64,6 +65,12 @@ contract MockNetworkMiddleware is ISymbioticNetworkMiddleware {
 
     function slashableCollateral(address _agent, uint48) external view returns (uint256 _slashableCollateral) {
         _slashableCollateral = mockSlashableCollateral[_agent];
+    }
+
+    function collateral(address _agent) external view returns (address collateralAddress) {
+        address vault = _storage.agentsToVault[_agent];
+        if (vault == address(0)) return address(0);
+        collateralAddress = mockCollateralAddressByVault[_agent][vault];
     }
 
     function subnetworkIdentifier(address _agent) public pure returns (uint96 id) {


### PR DESCRIPTION
We are implementing coverage caps, whereby each agent can only have up to a certain amount of USD coverage. This will curtail the risk of bad debt during liquidations from delegators using lower liquidity assets as collateral. Risks from bad oracle updates are mitigated as agents with impacted collateral will be unable to borrow above the LTV at the capped coverage.

Coverage caps are stored and set on the `Delegation` contract by the timelock. During the implementation upgrade the caps for current agents should be set atomically to prevent liquidations. Slashable collateral will not be affected by the cap, but the capped coverage affects the health of the agent and can trigger liquidations.

The collateral asset per agent will now also be exposed on the `Delegation` contract. From there liquidators can fetch all the required information for liquidating. 